### PR TITLE
Adding Scala-docs for Shapeless, Postgresql and Elasticsearch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val noPublishSettings = Seq(
 
 lazy val docSettings = Seq(
   autoAPIMappings := true,
-  unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(commons),
+  unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(commons, postgres, elasticsearch, shapeless),
   site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "api"),
   ghpagesNoJekyll := false,
   siteMappings ++= Seq(


### PR DESCRIPTION
The Scaladoc appears to only contain documentation for the core extensions and not the Shapeless, Postgresql and Elasticsearch extensions.  This pull request adds the scala doc for those additional extensions.