### PR TITLE
allow downstream to deliver more than asked

### DIFF
--- a/commons/src/test/scala/SourceExtSpec.scala
+++ b/commons/src/test/scala/SourceExtSpec.scala
@@ -46,7 +46,7 @@ class SourceExtSpec extends FlatSpec with Matchers with ScalaFutures {
     ) { res => assert(res == elements) }
   }
 
-  it should "ignore unwanted elements by downstream (with a warning)" in {
+  it should "buffer unwanted elements by downstream" in {
     whenReady(
       bulkPullerAsync(0L) { (counter, nbElemToPush) =>
         val toPush = elements.drop(counter.toInt).take(nbElemToPush + 10)


### PR DESCRIPTION
This strategy can be used for example when requesting
external REST Apis to minimize the number of requests.

The elements that are not needed are buffered internally
to be send later.