### PR TITLE
Upgrade to Akka 2.4.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ lazy val commons = project.in(file("commons"))
   .settings(
     name := "akka-stream-extensions",
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-stream-experimental" % "2.0.1"
+      "com.typesafe.akka" %% "akka-stream" % "2.4.2"
     ),
     commonSettings,
     publishSettings

--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,7 @@ lazy val postgres = project.in(file("extensions/postgres"))
     name := "akka-stream-extensions-postgres",
     resolvers += Resolver.bintrayRepo("softprops", "maven"),
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-stream-experimental" % "2.0.1",
+      "com.typesafe.akka" %% "akka-stream" % "2.4.2",
       "org.postgresql" % "postgresql"  % "9.3-1102-jdbc4"
     ),
     commonSettings,
@@ -117,7 +117,7 @@ lazy val elasticsearch = project.in(file("extensions/elasticsearch"))
   .settings(
     name := "akka-stream-extensions-elasticsearch",
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-stream-experimental" % "2.0.1",
+      "com.typesafe.akka" %% "akka-stream" % "2.4.2",
       "org.elasticsearch" % "elasticsearch" % "1.3.2"
     ),
     commonSettings,

--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,7 @@ lazy val shapeless = project.in(file("extensions/shapeless"))
  .settings(
    name := "akka-stream-extensions-shapeless",
    libraryDependencies ++= Seq(
-     "com.typesafe.akka" %% "akka-stream-experimental" % "2.0.1",
+     "com.typesafe.akka" %% "akka-stream" % "2.4.2",
      "com.chuusai"       %% "shapeless"                % "2.2.0-RC6"
    ),
    commonSettings,

--- a/commons/src/main/scala/SourceExt.scala
+++ b/commons/src/main/scala/SourceExt.scala
@@ -3,6 +3,7 @@ package com.mfglabs.stream
 import java.io.{BufferedInputStream, FileInputStream, InputStream, File}
 import java.util.zip.GZIPInputStream
 
+import akka.NotUsed
 import akka.stream._
 import akka.stream.scaladsl._
 import akka.util.ByteString
@@ -157,7 +158,7 @@ trait SourceExt {
    * @tparam B
    * @return
    */
-  def seededLazyAsync[A, B, M](futB: => Future[B])(f: B => Source[A, M]): Source[A, Unit] =
+  def seededLazyAsync[A, B, M](futB: => Future[B])(f: B => Source[A, M]): Source[A, NotUsed] =
     singleLazyAsync(futB).map(f).flatMapConcat(identity)
 
   /**
@@ -167,7 +168,7 @@ trait SourceExt {
    * @tparam A
    * @return
    */
-  def singleLazyAsync[A](fut: => Future[A]): Source[A, Unit] = singleLazy(fut).mapAsync(1)(identity)
+  def singleLazyAsync[A](fut: => Future[A]): Source[A, NotUsed] = singleLazy(fut).mapAsync(1)(identity)
 
   /**
    * Create a source from a Lazy Value that will be evaluated only when the stream is materialized.
@@ -176,7 +177,7 @@ trait SourceExt {
    * @tparam A
    * @return
    */
-  def singleLazy[A](a: => A): Source[A, Unit] = Source.single(() => a).map(_())
+  def singleLazy[A](a: => A): Source[A, NotUsed] = Source.single(() => a).map(_())
 
   /**
    * Create an infinite source of the same Async Lazy value evaluated only when the stream is materialized.

--- a/extensions/elasticsearch/src/main/scala/elasticsearchExtensions.scala
+++ b/extensions/elasticsearch/src/main/scala/elasticsearchExtensions.scala
@@ -1,6 +1,7 @@
 package com.mfglabs.stream
 package extensions.elasticsearch
 
+import akka.NotUsed
 import akka.stream.scaladsl._
 import com.mfglabs.stream.{ExecutionContextForBlockingOps, SourceExt}
 import org.elasticsearch.action.search.SearchType
@@ -25,7 +26,7 @@ trait EsStream {
    * @return
    */
   def queryAsStream(query: QueryBuilder, index: String, `type`: String, scrollKeepAlive: FiniteDuration, scrollSize: Int)
-                   (implicit es: EsClient, ec: ExecutionContextForBlockingOps): Source[String, Unit] = {
+                   (implicit es: EsClient, ec: ExecutionContextForBlockingOps): Source[String, NotUsed] = {
     implicit val ecValue = ec.value
 
     lazy val futInitSearchResp = Future {

--- a/extensions/postgres/src/main/scala/postgresExtensions.scala
+++ b/extensions/postgres/src/main/scala/postgresExtensions.scala
@@ -3,6 +3,7 @@ package extensions.postgres
 
 import java.io._
 
+import akka.NotUsed
 import akka.stream._
 import akka.stream.scaladsl._
 import akka.util.ByteString
@@ -81,7 +82,7 @@ trait PgStream {
    */
   def insertStreamToTable(schema: String, table: String, options: Map[String, String], pgVersion : PostgresVersion = PostgresVersion.Nine, nbLinesPerInsertionBatch: Int = 20000,
                           chunkInsertionConcurrency: Int = 1)
-                         (implicit conn: PGConnection, ec: ExecutionContextForBlockingOps): Flow[ByteString, Long, Unit] = {
+                         (implicit conn: PGConnection, ec: ExecutionContextForBlockingOps): Flow[ByteString, Long, NotUsed] = {
     val optsStr = optionsToStr(pgVersion, options)
     val copyQuery = s"COPY ${schema}.${table} FROM STDIN $optsStr"
     val copyManager = conn.getCopyAPI()


### PR DESCRIPTION
2.4.2 has landed, and with it, a finalized Akka-Streams API. This so far is a quick "Update the Unit to NotUsed" on the materialization type, but it probably makes sense to update the custom stages to use a non-deprecated API, as well as doing a pass over and deprecating duplicate methods.

I have zero clue what I was doing with the shapeless thing, but it compiles and the tests pass. I have no clue whether that is sufficient to merge anything.